### PR TITLE
Removed unused import that fails on Komodo 8.5

### DIFF
--- a/components/koMako_UDL_Language.py
+++ b/components/koMako_UDL_Language.py
@@ -6,23 +6,22 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 #    The above copyright notice and this permission notice shall be included in
 #    all copies or substantial portions of the Software.
-# 
+#
 #    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 #    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 #    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-#    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE 
+#    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 #    USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Komodo Mako language service.
 
 import logging
 from koXMLLanguageBase import koHTMLLanguageBase
-from codeintel2 import lang_html, lang_javascript
 
 log = logging.getLogger("koMakoLanguage")
 #log.setLevel(logging.DEBUG)
@@ -49,26 +48,3 @@ class KoMakoLanguage(koHTMLLanguageBase):
         'CSS': 'CSS',
         'SSL': 'Python',
     }
-    #TODO: Update 'lang_from_udl_family' as appropriate for your
-    #      lexer definition. There are four UDL language families:
-    #           M (markup), i.e. HTML or XML
-    #           CSL (client-side language), e.g. JavaScript
-    #           SSL (server-side language), e.g. Perl, PHP, Python
-    #           TPL (template language), e.g. RHTML, Django, Smarty
-    #      'lang_from_udl_family' maps each UDL family code (M,
-    #      CSL, ...) to the sub-langauge name in your language.
-    #      Some examples:
-    #        lang_from_udl_family = {   # A PHP file can contain
-    #           'M': 'HTML',            #   HTML
-    #           'SSL': 'PHP',           #   PHP
-    #           'CSL': 'JavaScript',    #   JavaScript
-    #        }
-    #        lang_from_udl_family = {   # An RHTML file can contain
-    #           'M': 'HTML',            #   HTML
-    #           'SSL': 'Ruby',          #   Ruby
-    #           'CSL': 'JavaScript',    #   JavaScript
-    #           'TPL': 'RHTML',         #   RHTML template code
-    #        }
-    #        lang_from_udl_family = {   # A plain XML can just contain
-    #           'M': 'XML',             #   XML
-    #        }


### PR DESCRIPTION
This import is making problems on Komodo 8.5, but it seems to be unused anyways.
